### PR TITLE
Migrate from SnoopPrecompile to PrecompileTools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 PrimitiveCollisions = "3b8dc6f2-bddc-4c88-9cf9-9f37a0c17a29"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
@@ -19,7 +19,7 @@ ModelingToolkit = "8.28"
 PrimitiveCollisions = "0.1.0"
 Reexport = "1.2"
 SciMLBase = "1.63"
-SnoopPrecompile = "1.0"
+PrecompileTools = "1.0"
 StaticArrays = "1.5"
 julia = "1"
 

--- a/src/Collide.jl
+++ b/src/Collide.jl
@@ -16,9 +16,9 @@ include("entity.jl")
 export Simulation
 include("simulate.jl")
 
-using SnoopPrecompile: SnoopPrecompile
+using PrecompileTools: PrecompileTools
 
-SnoopPrecompile.@precompile_all_calls begin
+PrecompileTools.@compile_workload begin
     e = Entity(; name = :a, shape = Rect(1.0, 1.0), linear_drag = 0.5)
     e2 = Entity(;
         name = :b,


### PR DESCRIPTION
This pull request migrates the package from [SnoopPrecompile](https://github.com/timholy/SnoopCompile.jl/tree/master/SnoopPrecompile) to [PrecompileTools](https://github.com/JuliaLang/PrecompileTools.jl).
PrecompileTools is **nearly a drop-in replacement** except that there are **changes in naming and how developers locally disable precompilation** (to make their development workflow more efficient). These changes are described in [PrecompileTool's enhanced documentation](https://julialang.github.io/PrecompileTools.jl/stable/), which also includes instructions for users on how to set up custom "Startup" packages, handling precompilation tasks that are not amenable to workloads, and tips for troubleshooting.

Why the new package? It meets several goals:

- The name "SnoopPrecompile" was easily confused with "SnoopCompile," a package designed for *analyzing* rather than *enacting* precompilation.
- SnoopPrecompile/PrecompileTools has become (directly or indirectly) a dependency for much of the Julia ecosystem, a trend that seems likely to grow with time. It makes sense to host it in a more central location than one developer's personal account.
- As Julia's own stdlibs migrate to become independently updateable (true for DelimitedFiles in Julia 1.9, with others anticipated for Julia 1.10), several of them would like to use PrecompileTools for high-quality precompilation. That requires making PrecompileTools its own "upgradable stdlib."
- We wanted to change the [use of Preferences](https://github.com/timholy/SnoopCompile.jl/issues/356) to make packages more independent of one another. Since this would have been a breaking change, it seemed like a good opportunity to fix other issues, too.

For more information and discussion, see this [discourse post](https://discourse.julialang.org/t/ann-snoopprecompile-precompiletools/97882).
